### PR TITLE
bump to langchain 0.1.5

### DIFF
--- a/choose_your_own_adventure/requirements.txt
+++ b/choose_your_own_adventure/requirements.txt
@@ -1,3 +1,3 @@
-langchain==0.0.354
+langchain==0.1.15
 python-dotenv==1.0.0
 octoai-sdk==0.8.2

--- a/choose_your_own_adventure/requirements.txt
+++ b/choose_your_own_adventure/requirements.txt
@@ -1,3 +1,3 @@
-langchain==0.1.15
+langchain==0.1.5
 python-dotenv==1.0.0
 octoai-sdk==0.8.2

--- a/doctalk/backend/app/requirements.txt
+++ b/doctalk/backend/app/requirements.txt
@@ -1,6 +1,6 @@
 beautifulsoup4==4.12.2
 datasets==2.16.1
-langchain==0.1.4
+langchain==0.1.5
 langchain-community==0.0.16
 langchain-core==0.1.17
 octoai-sdk==0.2.0

--- a/recipe_generator/requirements.txt
+++ b/recipe_generator/requirements.txt
@@ -1,1 +1,1 @@
-octoai-sdk
+octoai-sdk==0.8.2

--- a/simple_chat/requirements.txt
+++ b/simple_chat/requirements.txt
@@ -1,3 +1,3 @@
-langchain==0.0.354
+langchain==0.1.15
 python-dotenv==1.0.0
 octoai-sdk==0.8.2

--- a/simple_chat/requirements.txt
+++ b/simple_chat/requirements.txt
@@ -1,3 +1,3 @@
-langchain==0.1.15
+langchain==0.1.5
 python-dotenv==1.0.0
 octoai-sdk==0.8.2


### PR DESCRIPTION
Langchain 0.1.5 contains important fixes for OctoAI LLMs support and embedding support