### PR TITLE
Fix requirements.txt and README for fine-tuning code samples

### DIFF
--- a/octoai_openpipe_finetuning_for_toxicity_detection/README.md
+++ b/octoai_openpipe_finetuning_for_toxicity_detection/README.md
@@ -1,6 +1,6 @@
-# Toxicity classification at 125x lower costs and better-than-GPT 4 quality, with fine-tuneed Mistral 7B
+# Toxicity classification at 60x lower costs and better-than-GPT 4 quality, with fine-tuneed Mistral 7B
 
-This repository contains the necessary code to collect a dataset from GPT-4 responses and then to evaluate a fine-tuned model against various OctoAI and OpenAI models. If you want to check out the cost efficiency gains from fine-tuning, check out [this blog post](...).
+This repository contains the necessary code to collect a dataset from GPT-4 responses and then to evaluate a fine-tuned model against various OctoAI and OpenAI models. If you want to check out the cost efficiency gains from fine-tuning, check out [this blog post](https://octo.ai/blog/fine-tuned-mistral-7b-delivers-over-60x-lower-costs-and-comparable-quality-to-gpt-4/).
 
 Feel free to grab this code and an `OCTOAI_API_TOKEN`, and
 build your LLM-powered applications today!

--- a/octoai_openpipe_finetuning_for_toxicity_detection/requirements.txt
+++ b/octoai_openpipe_finetuning_for_toxicity_detection/requirements.txt
@@ -2,6 +2,7 @@ openpipe==4.4.2
 octoai-sdk==0.8.3
 python-dotenv==1.0.1
 tiktoken>=0.5.0,<0.6.0
+scikit-learn==1.5.0
 transformers==4.37.2
 datasets
 tenacity


### PR DESCRIPTION
During investigation of an issue reported by @PreciselyAlyss with the example code for the fine-tuning for toxicity classification blog post, I found that the `requirements.txt` file was missing the `scikit-learn` dependency.

Also updated the README with the correct title, and a link to the blog post.