### PR TITLE
fix: update prompt in pdf summarizer to improve results

### DIFF
--- a/pdf_summarizer/nextjs/src/pages/api/summarize.js
+++ b/pdf_summarizer/nextjs/src/pages/api/summarize.js
@@ -9,7 +9,11 @@ export default async function handler(req, res) {
     "messages": [
       {
         "role": "system",
-        "content": `Summarize the following text:${body.text}`
+        "content": "You are a tool that summarizes text. This tool is a web appliation that extracts text from a PDF document and produces a formatted list of the main points in the given text. Do not communicate with the user directly."
+      },
+      {
+        "role": "assistant",
+        "content": `text:\n${body.text}`
       },
     ],
     "model": "mixtral-8x7b-instruct-fp16",


### PR DESCRIPTION
The existing prompt template in the summarize API @ `/pdf_summarizer/nextjs/src/api/summarize.js` is producing jibberish results:

<img width="2186" alt="image" src="https://github.com/octoml/octoai-textgen-cookbook/assets/175033845/b1fcfc17-2328-4b20-9bc1-bbe4a75d4c3e">

updated the prompt to closely align with the local node script:

<img width="2257" alt="image" src="https://github.com/octoml/octoai-textgen-cookbook/assets/175033845/87f6ba1c-68bc-4166-9576-54b3bc2d26e7">
