### PR TITLE
minor fix for tool call notebook

### DIFF
--- a/llama31_tools/llama31_tools.ipynb
+++ b/llama31_tools/llama31_tools.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 2,
    "id": "46477225-22df-4fe5-9b6d-982fdf74634c",
    "metadata": {},
    "outputs": [
@@ -51,7 +51,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 3,
    "id": "ab78649c-e7d6-44df-8d9d-66c3234c49c7",
    "metadata": {},
    "outputs": [],
@@ -74,7 +74,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 4,
    "id": "7f9630be-d30a-44d2-b3a4-e9433ef22d26",
    "metadata": {},
    "outputs": [
@@ -662,7 +662,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 5,
    "id": "8a9a6a53-3668-44fa-8b41-6870baf4c50f",
    "metadata": {},
    "outputs": [
@@ -670,23 +670,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The poles of the function (z^2-4) / ((z-2)^4*(z^2+5z+7)) are:\n",
-      "\n",
-      "* z = 2 (order 3 pole)\n",
-      "* z = 1/2 (-5 - i sqrt(3)) (simple pole)\n",
-      "* z = 1/2 (-5 + i sqrt(3)) (simple pole)\n",
-      "\n",
-      "The zero of the function is:\n",
-      "\n",
-      "* z = -2 (simple zero)\n",
-      "\n",
-      "The residues of the function at the poles are:\n",
-      "\n",
-      "* Res_(z = 2)((z^2 - 4)/((z - 2)^4 (z^2 + 5 z + 7))) = 17/3087\n",
-      "* Res_(z = 1/2 (-5 - i sqrt(3)))((z^2 - 4)/((z - 2)^4 (z^2 + 5 z + 7))) = (-sqrt(3) + i)/(162 sqrt(3) + 180 i)\n",
-      "* Res_(z = 1/2 (-5 + i sqrt(3)))((z^2 - 4)/((z - 2)^4 (z^2 + 5 z + 7))) = (4 i (sqrt(3) + i))/(sqrt(3) (sqrt(3) + 9 i)^3)\n",
-      "\n",
-      "The pole-zero plot of the function is also provided.\n"
+      "The status of your flight AA100 for tomorrow, 2024-07-27, is On Time.\n"
      ]
     }
    ],
@@ -778,7 +762,7 @@
     "        tools=tools,\n",
     "        tool_choice=\"auto\",\n",
     "    )\n",
-    "    print(completion.choices[0].message.content)"
+    "    print(function_enriched_response.choices[0].message.content)"
    ]
   },
   {
@@ -986,7 +970,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.4"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Updating a variable reference to fix the generic function call example, prevent repeat wolfram output.

Other diffs related to `execution_count` are hidden as far as I can tell.